### PR TITLE
New term: z-statistic

### DIFF
--- a/src/ontology/stato.owl
+++ b/src/ontology/stato.owl
@@ -24989,7 +24989,7 @@ http://stat.ethz.ch/R-manual/R-patched/library/stats/html/binom.test.html</Liter
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <IRI>#z-statistic</IRI>
-        <Literal datatypeIRI="&rdf;PlainLiteral">z-statistic is a statistic computed from observations and used to produce a p-value in statistical test when compared to a Standard Normal Distribution.</Literal>
+        <Literal datatypeIRI="&rdf;PlainLiteral">z-statistic is a statistic computed from observations and used to produce a p-value when compared to a Standard Normal Distribution in a statistical test called the z-test.</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://purl.obolibrary.org/obo/IAO_0000119"/>

--- a/src/ontology/stato.owl
+++ b/src/ontology/stato.owl
@@ -11,10 +11,10 @@
 
 <Ontology xmlns="http://www.w3.org/2002/07/owl#"
      xml:base="http://purl.obolibrary.org/obo/stato.owl"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      ontologyIRI="http://purl.obolibrary.org/obo/stato.owl">
     <Prefix name="" IRI="http://www.w3.org/2002/07/owl#"/>
     <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
@@ -23,40 +23,28 @@
     <Prefix name="rdfs" IRI="http://www.w3.org/2000/01/rdf-schema#"/>
     <Import>http://purl.obolibrary.org/obo/stato/obi_import.owl</Import>
     <Annotation>
-        <AnnotationProperty IRI="http://usefulinc.com/ns/doap#mailing-list"/>
-        <Literal datatypeIRI="&rdf;PlainLiteral">stat-ontology@googlegroups.com</Literal>
-    </Annotation>
-    <Annotation>
-        <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/license"/>
-        <Literal datatypeIRI="&xsd;anyURI">http://creativecommons.org/licenses/by/3.0/</Literal>
-    </Annotation>
-    <Annotation>
-        <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/creator"/>
-        <Literal datatypeIRI="&rdf;PlainLiteral">Orlaith Burke</Literal>
-    </Annotation>
-    <Annotation>
-        <AnnotationProperty abbreviatedIRI="owl:versionInfo"/>
-        <Literal datatypeIRI="&rdf;PlainLiteral">RC1.2</Literal>
+        <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/rights"/>
+        <Literal datatypeIRI="&xsd;anyURI">This Ontology is distributed under a Creative Commons Attribution License </Literal>
     </Annotation>
     <Annotation>
         <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/subject"/>
         <Literal xml:lang="en" datatypeIRI="&rdf;PlainLiteral">Statistical Method, Design of Experiment, Plots, Statistical Model</Literal>
     </Annotation>
     <Annotation>
-        <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/description"/>
-        <Literal datatypeIRI="&rdf;PlainLiteral">STATO is the statistical methods ontology. It contains concepts and properties related to statistical methods, probability distributions and other concepts related to statistical analysis, including relationships to study designs and plots.</Literal>
-    </Annotation>
-    <Annotation>
-        <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/creator"/>
-        <Literal datatypeIRI="&rdf;PlainLiteral">Alejandra Gonzalez-Beltran (http://orcid.org/0000-0003-3499-8262)</Literal>
-    </Annotation>
-    <Annotation>
         <AnnotationProperty IRI="http://usefulinc.com/ns/doap#bug-database"/>
         <Literal datatypeIRI="&rdf;PlainLiteral">https://github.com/ISA-tools/stato/issues</Literal>
     </Annotation>
     <Annotation>
+        <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/license"/>
+        <Literal datatypeIRI="&xsd;anyURI">http://creativecommons.org/licenses/by/3.0/</Literal>
+    </Annotation>
+    <Annotation>
         <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/contributor"/>
         <Literal datatypeIRI="&rdf;PlainLiteral">Thomas Nichols (http://orcid.org/0000-0002-4516-5103)</Literal>
+    </Annotation>
+    <Annotation>
+        <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/contributor"/>
+        <Literal datatypeIRI="&rdf;PlainLiteral">Chris Mungall (http://orcid.org/0000-0002-6601-2165)</Literal>
     </Annotation>
     <Annotation>
         <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/creator"/>
@@ -67,20 +55,32 @@
         <Literal datatypeIRI="&rdf;PlainLiteral">Nolan Nichols (http://orcid.org/0000-0003-1099-3328)</Literal>
     </Annotation>
     <Annotation>
-        <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/title"/>
-        <Literal datatypeIRI="&rdf;PlainLiteral">STATO: the statistical methods ontology</Literal>
+        <AnnotationProperty abbreviatedIRI="owl:versionInfo"/>
+        <Literal datatypeIRI="&rdf;PlainLiteral">RC1.2</Literal>
     </Annotation>
     <Annotation>
-        <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/rights"/>
-        <Literal datatypeIRI="&xsd;anyURI">This Ontology is distributed under a Creative Commons Attribution License </Literal>
-    </Annotation>
-    <Annotation>
-        <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/contributor"/>
-        <Literal datatypeIRI="&rdf;PlainLiteral">Chris Mungall (http://orcid.org/0000-0002-6601-2165)</Literal>
+        <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/description"/>
+        <Literal datatypeIRI="&rdf;PlainLiteral">STATO is the statistical methods ontology. It contains concepts and properties related to statistical methods, probability distributions and other concepts related to statistical analysis, including relationships to study designs and plots.</Literal>
     </Annotation>
     <Annotation>
         <AnnotationProperty IRI="http://usefulinc.com/ns/doap#homepage"/>
         <Literal datatypeIRI="&rdf;PlainLiteral">http://stato-ontology.org/</Literal>
+    </Annotation>
+    <Annotation>
+        <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/creator"/>
+        <Literal datatypeIRI="&rdf;PlainLiteral">Orlaith Burke</Literal>
+    </Annotation>
+    <Annotation>
+        <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/title"/>
+        <Literal datatypeIRI="&rdf;PlainLiteral">STATO: the statistical methods ontology</Literal>
+    </Annotation>
+    <Annotation>
+        <AnnotationProperty IRI="http://purl.org/dc/elements/1.1/creator"/>
+        <Literal datatypeIRI="&rdf;PlainLiteral">Alejandra Gonzalez-Beltran (http://orcid.org/0000-0003-3499-8262)</Literal>
+    </Annotation>
+    <Annotation>
+        <AnnotationProperty IRI="http://usefulinc.com/ns/doap#mailing-list"/>
+        <Literal datatypeIRI="&rdf;PlainLiteral">stat-ontology@googlegroups.com</Literal>
     </Annotation>
     <Declaration>
         <Class IRI="http://purl.obolibrary.org/obo/STATO_0000002"/>
@@ -1128,6 +1128,9 @@
     </Declaration>
     <Declaration>
         <Class IRI="#regression_model"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="#z-statistic"/>
     </Declaration>
     <Declaration>
         <Class IRI="#http://purl.obolibrary.org/obo/STATO_0000322"/>
@@ -8451,6 +8454,17 @@
         <Class IRI="http://purl.obolibrary.org/obo/STATO_0000107"/>
     </SubClassOf>
     <SubClassOf>
+        <Class IRI="#z-statistic"/>
+        <Class IRI="http://purl.obolibrary.org/obo/STATO_0000039"/>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#z-statistic"/>
+        <ObjectSomeValuesFrom>
+            <ObjectProperty IRI="http://purl.obolibrary.org/obo/OBI_0000295"/>
+            <Class IRI="http://purl.obolibrary.org/obo/STATO_0000052"/>
+        </ObjectSomeValuesFrom>
+    </SubClassOf>
+    <SubClassOf>
         <Class IRI="#http://purl.obolibrary.org/obo/STATO_0000322"/>
         <Class IRI="http://purl.obolibrary.org/obo/IAO_0000027"/>
     </SubClassOf>
@@ -8553,8 +8567,8 @@
         <ObjectProperty IRI="http://purl.obolibrary.org/obo/STATO_0000110"/>
     </InverseObjectProperties>
     <InverseObjectProperties>
-        <ObjectProperty IRI="http://purl.obolibrary.org/obo/STATO_0000001"/>
         <ObjectProperty IRI="http://purl.obolibrary.org/obo/STATO_0000004"/>
+        <ObjectProperty IRI="http://purl.obolibrary.org/obo/STATO_0000001"/>
     </InverseObjectProperties>
     <InverseObjectProperties>
         <ObjectProperty IRI="http://purl.obolibrary.org/obo/STATO_0000115"/>
@@ -24966,6 +24980,26 @@ http://stat.ethz.ch/R-manual/R-patched/library/stats/html/binom.test.html</Liter
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
         <IRI>#regression_model</IRI>
         <Literal xml:lang="en" datatypeIRI="&rdf;PlainLiteral">regression model</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="http://purl.obolibrary.org/obo/IAO_0000114"/>
+        <IRI>#z-statistic</IRI>
+        <IRI>http://purl.obolibrary.org/obo/IAO_0000120</IRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <IRI>#z-statistic</IRI>
+        <Literal datatypeIRI="&rdf;PlainLiteral">z-statistic is a statistic computed from observations and used to produce a p-value in statistical test when compared to a Standard Normal Distribution.</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty IRI="http://purl.obolibrary.org/obo/IAO_0000119"/>
+        <IRI>#z-statistic</IRI>
+        <Literal datatypeIRI="&rdf;PlainLiteral">stato</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#z-statistic</IRI>
+        <Literal datatypeIRI="&rdf;PlainLiteral">Z-statistic</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty IRI="http://purl.obolibrary.org/obo/IAO_0000112"/>


### PR DESCRIPTION
In this pull request we create a new term "z-statistic" (child of `stato:statistic`) with the following basic information:

```
uri: http://purl.obolibrary.org/obo/stato.owl#z-statistic (to be replaced by *an alphanumeric id*)

label: Z-statistic

textual defintion: z-statistic is a statistic computed from observations and used to produce a p-value in statistical test when compared to a Standard Normal Distribution.

definition source: STATO (similarly to t-statistic)

parent term: statistic
logical defintions: 
    'is specified input' of 'z-test' (http://purl.obolibrary.org/obo/STATO_0000052)

```

This term could be directly used in NIDM as a possible value for `nidm:statisticType` in a [nidm:StatisticMap](http://nidm.nidash.org/specs/nidm-results_dev.html#section-nidm:StatisticMap).

Please let me know what you think. Thank you in advance!
